### PR TITLE
adding fastqc report variables

### DIFF
--- a/scripts/qc_report_per_sample.rmd
+++ b/scripts/qc_report_per_sample.rmd
@@ -29,8 +29,8 @@ outFile <- params$outFile
 fastqc_dir <- params$fastqc_dir # TODO @Jan @Miri add that argument to the snakemake rule and the rendersite function?
 # TODO: @Jan snakemake needs to be run twice before and after the preprocessing
 # TODO: @Jan @Ricardo 
-fastqc_unprocessed <- "FASTQ_DIR/{sample}_unprocessed_fastqc.html"
-fastqc_processed <- "FASTQ_DIR/{sample}_unprocessed_fastqc.html"
+fastqc_unprocessed <- paste0(FASTQ_DIR,"/{sample}_unprocessed_fastqc.html")
+fastqc_processed <- paste0(FASTQ_DIR,"/{sample}_unprocessed_fastqc.html")
 
 ``` 
 ```{r printInputSettings, echo = FALSE, include = FALSE}

--- a/scripts/qc_report_per_sample.rmd
+++ b/scripts/qc_report_per_sample.rmd
@@ -20,11 +20,18 @@ library(stringr)
 library(magrittr)
 library(openssl)
 ```
+
 # Input Settings
 ```{r InputSettings, echo = FALSE, include = FALSE}
 coverage_file <- params$coverage_file
 sample_name <- params$sample_name
 outFile <- params$outFile
+fastqc_dir <- params$fastqc_dir # TODO @Jan @Miri add that argument to the snakemake rule and the rendersite function?
+# TODO: @Jan snakemake needs to be run twice before and after the preprocessing
+# TODO: @Jan @Ricardo 
+fastqc_unprocessed <- "FASTQ_DIR/{sample}_unprocessed_fastqc.html"
+fastqc_processed <- "FASTQ_DIR/{sample}_unprocessed_fastqc.html"
+
 ``` 
 ```{r printInputSettings, echo = FALSE, include = FALSE}
 # coverage_file <- 'tests/coverage/Test_merged_covs.csv'
@@ -66,8 +73,8 @@ DT::datatable(t(Coverage), options = list(searching = FALSE, paging = FALSE))
 ```
 ## FastQC and Trimming
 
-Download: [fastqc report of unprocessed data](/path/to/fastqc.html)  
-Download: [fastqc report of pre-processes data](/path/to/fastqc.html) 
+Download: [fastqc report of unprocessed data](fastqc_unprocessed)  
+Download: [fastqc report of pre-processes data](fastqc_processed) 
 
 
 

--- a/scripts/variantreport_p_sample.rmd
+++ b/scripts/variantreport_p_sample.rmd
@@ -180,6 +180,16 @@ getIdentCols <- function (dataframe) {
     }
     return(cols_new)
 }
+
+dedupeMuts <- function (mut, sigmut.df, dedup.df) {
+        # get variant group per mutation
+        duped_muts <- grep (mut, sigmut.df$value)
+        grouped <- sigmut.df$name[duped_muts]
+        groupName <- paste(grouped, collapse = ",")
+      
+        dedup.df$name[dedup.df$value == mut] <- groupName
+        return (dedup.df)
+}  
 ```
 
 ```{r development_parsing_deletions_properly, warning = F, include = FALSE}


### PR DESCRIPTION
! New input argument ! snakemake change needed: The report has two links that are supposed to link to the fastqc report htmls. I added now the variables for that and the locations where (according to the snakefile) the fastqc output goes. @Jan I think that needs to be changed to output htmls. Furthermore it needs to run twice (before and after trimming). @Miri @Jan this rmd now gets a new argument: fastqc_dir. I only changed it in the "input settings" chunk since I think the "params" header changed anyways with Miriams-renderSite-version