### PR TITLE
Clarify installation section in user_installation_doc

### DIFF
--- a/documentation/user_installation_doc.md
+++ b/documentation/user_installation_doc.md
@@ -19,7 +19,12 @@ To investigate the abundance of other existing species in the wastewater samples
 
 ## Install via guix
 
-This pipeline is going to be packaged in the [GNU Guix](https://gnu.org/s/guix) package manager soon. Right now in this preliminary state it has to be installed from source manually.
+Pre-built binaries for PiGx are available through [GNU Guix](https://gnu.org/s/guix), the functional package manager for reproducible, user-controlled software management. 
+You can install the PiGx SARS-CoV-2 pipeline with
+
+```sh
+guix install pigx-sars-cov2-ww
+```
 
 ## Install from source
 

--- a/documentation/user_installation_doc.md
+++ b/documentation/user_installation_doc.md
@@ -115,7 +115,7 @@ make check
 At this point you are able to run the pipeline from within the current directory `pigx_sarscov2_ww`. Use `--help` to see the available options.  To ensure that PiGx uses files from the source directory set the shell variable `PIGX_UNINSTALLED` to any value.
 
 ```sh
-PIGX_UNINSTALLED=t ./pigx-sars-cov2-ww --help
+pigx-sars-cov2-ww --help
 ```
 <details>
 <summary>toggle output</summary>
@@ -168,13 +168,13 @@ This pipeline was developed by the Akalin group at MDC in Berlin in 2017-2021.
 Though, to actually use it on your experimental data still more setup is required. Please follow [the steps to prepare the required databases](#prepare-databases) first and [prepare the input](#preparing-the-input). Then afterwards, you can run the pipeline from the source directory.
 
 ```sh
-PIGX_UNINSTALLED=t ./pigx-sars-cov2-ww [options] sample_sheet.csv
+pigx-sars-cov2-ww [options] sample_sheet.csv
 ```
 
 For example, with this command the pipeline is used for the included test data: 
 
 ```sh
-PIGX_UNINSTALLED=t ./pigx-sars-cov2-ww -s tests/settings.yaml tests/sample_sheet.csv
+pigx-sars-cov2-ww -s tests/settings.yaml tests/sample_sheet.csv
 ```
 
 ## Preparing the input
@@ -189,7 +189,7 @@ both files are described below.
 In order to generate template settings and sample sheet files, type
 
 ```sh
-PIGX_UNINSTALLED=t ./pigx-sars-cov2-ww --init
+pigx-sars-cov2-ww --init
 ```
 
 in the shell, and a boilerplate `sample_sheet.csv` and `settings.yaml` will be written to your current directory. An example for both files is provided in the `tests/` directory.

--- a/documentation/user_installation_doc.md
+++ b/documentation/user_installation_doc.md
@@ -112,7 +112,7 @@ make check
 
 # Getting started
 
-At this point you are able to run the pipeline from within the current directory `pigx_sarscov2_ww`. Use `--help` to see the available options.  To ensure that PiGx uses files from the source directory set the shell variable `PIGX_UNINSTALLED` to any value.
+At this point you are able to run the pipeline from within the current directory `pigx_sarscov2_ww`. Use `--help` to see the available options.
 
 ```sh
 pigx-sars-cov2-ww --help

--- a/documentation/user_installation_doc.md
+++ b/documentation/user_installation_doc.md
@@ -104,10 +104,9 @@ of the environment please address them by their absolute file name.
 Inside the environment you can then perform the usual build steps:
 
 ```sh
-./bootstrap.sh # to generate the "configure" script
-./configure
-make
-make check
+./bootstrap.sh
+./configure --prefix=/some/where
+make install
 ```
 
 # Getting started

--- a/documentation/user_installation_doc.md
+++ b/documentation/user_installation_doc.md
@@ -111,7 +111,7 @@ make install
 
 # Getting started
 
-At this point you are able to run the pipeline from within the current directory `pigx_sarscov2_ww`. Use `--help` to see the available options.
+At this point you are able to run PiGx SARS-CoV-2. To see all available options type `--help`.
 
 ```sh
 pigx-sars-cov2-ww --help
@@ -164,7 +164,7 @@ This pipeline was developed by the Akalin group at MDC in Berlin in 2017-2021.
 </details>
 </br>
 
-Though, to actually use it on your experimental data still more setup is required. Please follow [the steps to prepare the required databases](#prepare-databases) first and [prepare the input](#preparing-the-input). Then afterwards, you can run the pipeline from the source directory.
+Though, to actually use it on your experimental data still more setup is required. Please follow [the steps to prepare the required databases](#prepare-databases) first and [prepare the input](#preparing-the-input). Then afterwards, you can run the pipeline:
 
 ```sh
 pigx-sars-cov2-ww [options] sample_sheet.csv

--- a/documentation/user_installation_doc.md
+++ b/documentation/user_installation_doc.md
@@ -28,7 +28,7 @@ guix install pigx-sars-cov2-ww
 
 ## Install from source
 
-First, please clone this repository and change directory accordingly:
+Instead, if you want to install PiGx SARS-CoV-2 from source, please clone this repository and change directory accordingly:
 
 ```sh
 git clone https://github.com/BIMSBbioinfo/pigx_sarscov2_ww.git


### PR DESCRIPTION
Due to the release the commands for installation and how to get started got a lot simpler.
This removes any notes on PIGX_UNINSTALLED as this is more appropriate for HACKING file.