### PR TITLE
fix issue#70

### DIFF
--- a/scripts/report_scripts/variantreport_p_sample.Rmd
+++ b/scripts/report_scripts/variantreport_p_sample.Rmd
@@ -132,7 +132,15 @@ get_protein_mut <- function (vepfile){ # parse together from vep output "Protein
       #in the beginning of the line or include that step here. 
     
     # parsing snv and protmut location
+    # parsing gene mutation
+    gene_mutation <- data.frame(gene_mut_loc = str_split_fixed(vepfile.df$Location,"[:-]+", n=3),
+                                nucleotides = str_split_fixed(
+                                                str_split_fixed(vepfile.df$Uploaded_variation, 
+                                                                "[_-]+", n=4) [,4], "/", n=2))
+    gene_mutation$gene_mut <- paste0(gene_mutation$nucleotides.1, gene_mutation$gene_mut_loc.2, gene_mutation$nucleotides.2)
+                                                                   
     locations <- data.frame(gene_mut_loc = str_split_fixed(vepfile.df$Location,"[:-]+", n=3),
+                            gene_mut = gene_mutation$gene_mut,
                             prot_mut_loc = vepfile.df$Protein_position, 
                             AAs = str_split_fixed(vepfile.df$Amino_acids, "/",2), 
                             Conseq = vepfile.df$Consequence,
@@ -140,7 +148,7 @@ get_protein_mut <- function (vepfile){ # parse together from vep output "Protein
     locations <- dplyr::na_if(locations,'')
     
     # delete all rows with no protein position value
-    locations <- locations %>% filter(!grepl("^-", prot_mut_loc))
+    locations <- distinct(locations %>% filter(!grepl("^-", prot_mut_loc)))
     # specific B117 mutations: 21990-21993, 21764-21770, maybe also 3675-3677, 69-70 - all there
   
     deletions.df <- locations
@@ -290,10 +298,11 @@ variant_protein_mut <- dplyr::left_join(variant_protein_mut, sigmuts_deduped, by
 lofreq.info <- as_data_frame(parse_snv_csv(params$snv_file)) 
 vep.info <- variant_protein_mut
 
-# one aa mutation can have different codon mutations reportet with different freqs- those have to be summed up
+complete.df <- dplyr::left_join(lofreq.info, vep.info, by = c('gene_mut'='gene_mut'), copy = T)
+# one aa mutation can have different codon mutations reported with different freqs- those have to be summed up
 complete.df <- complete.df %>%
-  group_by(across(c(-freq,-gene_mut))) %>%
-  summarise(freq = sum(as.numeric(freq)), gene_mut = NA) %>%
+  group_by(across(c(-freq,-gene_mut,AA_mut))) %>%
+  summarise(freq = sum(as.numeric(freq)), gene_mut = paste(gene_mut, collapse = ",")) %>%
   ungroup()
 
 # sorting in mutations that match variants of concerns

--- a/scripts/report_scripts/variantreport_p_sample.Rmd
+++ b/scripts/report_scripts/variantreport_p_sample.Rmd
@@ -282,12 +282,7 @@ for (mut in sig_mutations.df$value) {
 variant_protein_mut <- get_protein_mut(params$vep_file)
 # match the variant names according to the signature mutations, if there is no signature mutation no name will be given
 variant_protein_mut <- dplyr::left_join(variant_protein_mut, sigmuts_deduped, by = c('AA_mut'='value'))
-# filter for mutations which are signature mutations
-match.df <- variant_protein_mut %>%
-                    filter(!is.na(name))
-# filter for everything that is not a signature mutation
-nomatch.df <- variant_protein_mut %>%
-                        filter(is.na(name))
+
 ```
 
 ```{r merge_vep_with_lofreq_info, message=F, warning=F, include = FALSE}
@@ -295,9 +290,13 @@ nomatch.df <- variant_protein_mut %>%
 lofreq.info <- as_data_frame(parse_snv_csv(params$snv_file)) 
 vep.info <- variant_protein_mut
 
-complete.df <- dplyr::left_join(lofreq.info, vep.info, by = c('gene_pos'='gene_mut_loc.2'), copy = T)
+# one aa mutation can have different codon mutations reportet with different freqs- those have to be summed up
+complete.df <- complete.df %>%
+  group_by(across(c(-freq,-gene_mut))) %>%
+  summarise(freq = sum(as.numeric(freq)), gene_mut = NA) %>%
+  ungroup()
 
-# TODO: redundant step from previous chunk can be removed
+# sorting in mutations that match variants of concerns
 match.df <- complete.df %>%
                     filter(!is.na(name))
 nomatch.df <- complete.df %>%

--- a/scripts/report_scripts/variantreport_p_sample.Rmd
+++ b/scripts/report_scripts/variantreport_p_sample.Rmd
@@ -180,16 +180,16 @@ deconv <- function (bulk,sig){
   #' and bulk frequency values derived by the SNV caller
   #' it was build by Altuna
   
-  rlm_model = suppressWarnings(MASS::rlm(sig,bulk, maxit = 100))
+  rlm_model <- suppressWarnings(MASS::rlm(sig,bulk, maxit = 100))
       
       
-  rlm_coefficients = rlm_model$coefficients
+  rlm_coefficients <- rlm_model$coefficients
   
-  rlm_coefficients = ifelse(rlm_coefficients < 0, 0, rlm_coefficients)
+  rlm_coefficients <- ifelse(rlm_coefficients < 0, 0, rlm_coefficients)
   
-  sumOfCof = sum(rlm_coefficients)
+  sumOfCof <- sum(rlm_coefficients)
   
-  rlm_coefficients = rlm_coefficients / sumOfCof  #normalize so coefficients add to 1
+  rlm_coefficients <- rlm_coefficients / sumOfCof  #normalize so coefficients add to 1
   
   as.vector(rlm_coefficients)
 }


### PR DESCRIPTION
* if multiple genome mutation cause the same protein mutation - they will be merged and frequencies summed up   

* vep info parses now also the genome mutation and vep info and lofreq info are merged by genome mutation now. Merging by genome location only lead to bugs if different genome mutations occured in the same location 