### PR TITLE
critical fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,7 @@ AC_SUBST_FILE(PIPELINE_META)
 PIPELINE_META=$srcdir/META
 AC_CONFIG_FILES([Makefile META etc/settings.yaml])
 AC_CONFIG_FILES([tests/tests/vep.sh], [chmod +x tests/tests/vep.sh])
+AC_CONFIG_FILES([tests/tests/test_deconvolution.R], [chmod +x tests/tests/test_deconvolution.R])
 AC_CONFIG_FILES([scripts/download_databases.sh], [chmod +x scripts/download_databases.sh])
 AC_CONFIG_FILES([qsub-template.sh:pigx-common/common/qsub-template.sh.in])
 AC_CONFIG_FILES([pigx-sars-cov2-ww:pigx-common/common/pigx-runner.in], [chmod +x pigx-sars-cov2-ww])

--- a/scripts/report_scripts/index.Rmd
+++ b/scripts/report_scripts/index.Rmd
@@ -580,7 +580,7 @@ genome and proportion of covered signature mutation locations. Results from samp
 ```{r title_quality_score, echo=FALSE, message=FALSE, warning=FALSE, results = 'asis'}
     # table displaying bad samples which are not further inlcuded 
     cat("\n Table 1: Discarded samples not matching the provided sample quality scoring") # TODO refine this text
- ```
+```
 
 ```{r table_ample_quality_score, echo=FALSE, message=FALSE, warning=FALSE}
 

--- a/scripts/report_scripts/taxonomic_classification.Rmd
+++ b/scripts/report_scripts/taxonomic_classification.Rmd
@@ -46,7 +46,7 @@ of unaligned reads.
 
 This interactive multi-layered pie chart displays the proportions of the classified taxons found in the sample. Shown are the taxonomy classes as nested sectors, with decreasing hierarchy from the center towards the periphery. The input values can be found in the table below. 
 
-<iframe id="krona" style="min-height: 100vh" width="100%" onload="this.height = this.contentWindow.document.body.scrollHeight;" src="./`r basename(params$krona_file)`"></iframe>
+<iframe id="krona" style="min-height: 100vh" width="100%" onload="this.height = this.contentWindow.document.body.scrollHeight;" src="`r params$krona_file`"></iframe>
 
 <font size="3"> 
 **Magnitude:** number of fragments covered by currently chosen supergroup displayed in the white middle of the circle   


### PR DESCRIPTION
Taxonomic_report: iframe call searched in the wrong directory for the krona report

index: a whitespace led to fail of the "title_quality_score" chunk