### PR TITLE
Rename

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -41,10 +41,10 @@ You can run the pipeline from the source directory without installing
 it by setting the `PIGX_UNINSTALLED` shell variable to any value.  This command runs the pipeline on the included test data:
 
 ```sh
-PIGX_UNINSTALLED=t ./pigx-sars-cov2-ww -s tests/settings.yaml tests/sample_sheet.csv
+PIGX_UNINSTALLED=t ./pigx-sars-cov-2 -s tests/settings.yaml tests/sample_sheet.csv
 ```
 
-Please, also see https://github.com/BIMSBbioinfo/pigx_sarscov2_ww/blob/main/documentation/user_installation_doc.md for setting up the pipeline and the needed databases.
+Please, also see https://github.com/BIMSBbioinfo/pigx_sars-cov-2/blob/main/documentation/user_installation_doc.md for setting up the pipeline and the needed databases.
 
 ## Collaborating
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4
 
 nodist_bin_SCRIPTS = \
-  pigx-sars-cov2-ww
+  pigx-sars-cov-2
 
 dist_pkglibexec_SCRIPTS = \
   snakefile.py
@@ -71,8 +71,8 @@ clean-local:
 CLEANFILES = $(nodist_bin_SCRIPTS) config.json
 
 integration:
-	$(AM_TESTS_ENVIRONMENT) $(abs_top_srcdir)/pigx-sars-cov2-ww --printshellcmds -s tests/settings.yaml tests/sample_sheet.csv
+	$(AM_TESTS_ENVIRONMENT) $(abs_top_srcdir)/pigx-sars-cov-2 --printshellcmds -s tests/settings.yaml tests/sample_sheet.csv
 
 # Build docker image with Guix
 docker: dist
-	guix pack -C none -e '(load "guix.scm")' --with-source=pigx_sars-cov2-ww-$(VERSION).tar.gz -f docker -S /bin=bin -S /lib=lib -S /share=share glibc-utf8-locales tzdata coreutils bash
+	guix pack -C none -e '(load "guix.scm")' --with-source=pigx_sars-cov-2-$(VERSION).tar.gz -f docker -S /bin=bin -S /lib=lib -S /share=share glibc-utf8-locales tzdata coreutils bash

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # PiGx SARS-CoV-2 Wastewater Sequencing Pipeline
 
-**Copyright 2021: Vic-Fabienne Schumann, Ricardo Wurmus, Miriam Faxel, Jan Dohmen, Rafael Cuadrat, Bora Uyar, Vedran Franke, Alexander Blume, and Altuna Akalin.**
+**Copyright 2021-2022: Vic-Fabienne Schumann, Ricardo Wurmus, Miriam Faxel, Jan Dohmen, Rafael Cuadrat, Bora Uyar, Vedran Franke, Alexander Blume, and Altuna Akalin.**
 **This work is distributed under the terms of the GNU General Public License, version 3 or later.  It is free to use for all purposes.**
 
 -----------

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ PiGx SARS-CoV-2 is a pipeline for analysing data from sequenced wastewater sampl
 lineages of SARS-CoV-2. It was developed for wastewater samples, which are enriched for SARS-CoV-2. 
 The pipeline can be used for continuous sampling. The output of the PiGx SARS-CoV-2 pipeline is summarized in a report
 which provides an intuitive visual overview about the development of variant abundance over time and location 
-(see our [example report](https://github.com/BIMSBbioinfo/pigx_sarscov2_ww#sample-reports)). 
+(see our [example report](https://github.com/BIMSBbioinfo/pigx_sars-cov-2#sample-reports)).
 Additionally there will be more detailed reports per sample, which cover the quality control of the samples, 
 the detected variants and a taxonomic classification of all unaligned reads. This version of the pipeline was designed 
-to work with paired-end amplicon sequencing data generated using the ARTIC nCoV-2019 primers.   
+to work with paired-end amplicon sequencing data generated using the ARTIC nCoV-2019 primers.
 
 Features to enable e.g. single-end input are currently under development. We are happy to hear about any other feature 
 request! Please consider using the Issue Tracker for this. 
@@ -27,14 +27,14 @@ request! Please consider using the Issue Tracker for this.
 
 ## Databases
 Some tools require some databases to be installed locally. For this please either see the Documentation below or run 
-[download_databases.sh](https://github.com/BIMSBbioinfo/pigx_sarscov2_ww/blob/main/scripts/download_databases.sh.in) after
+[download_databases.sh](https://github.com/BIMSBbioinfo/pigx_sars-cov-2/blob/main/scripts/download_databases.sh.in) after
 the pipeline is installed. 
 
 ## Installation via Guix (recommended)
 
 You can install this pipeline with all its dependencies using GNU Guix:
 ```sh 
-guix install pigx-sars-cov2-ww
+guix install pigx-sars-cov-2
 ```
 
 Using GNU Guix has many advantages in terms of reproducibility of your projects (see e.g. [here](https://academic.oup.com/gigascience/article/7/12/giy123/5114263)) 
@@ -43,7 +43,7 @@ If you don't have GNU Guix on your system you can also consider using [GNU Guix 
 
 ## Installation from source
 
-You can also install PiGx-SARS-CoV-2 from source manually. Make sure that all the required dependencies (for this see e.g [configure.ac](https://github.com/BIMSBbioinfo/pigx_sarscov2_ww/blob/main/configure.ac)) 
+You can also install PiGx-SARS-CoV-2 from source manually. Make sure that all the required dependencies (for this see e.g [configure.ac](https://github.com/BIMSBbioinfo/pigx_sars-cov-2/blob/main/configure.ac))
 are installed e.g. by installing them through a package manager like Conda. However, we can highly recommend using Guix (see above)
 
 <details>
@@ -100,19 +100,19 @@ Will be available soon
 # Documentation
 
 Please see our documentation in order to find out about more details e.g. about the required structure of the input files:
-https://bioinformatics.mdc-berlin.de/pigx_docs/pigx-sars-cov2-ww.html
+https://bioinformatics.mdc-berlin.de/pigx_docs/pigx-sars-cov-2.html
 
 # Sample Reports
 
-See as example the HTML report produced by PiGx SARS-Cov-2 used for 
+See as example the HTML report produced by PiGx SARS-CoV-2 used for
 ["COVID-19 infection dynamics revealed by SARS-CoV-2 wastewater sequencing analysis and deconvolution"](https://www.medrxiv.org/content/10.1101/2021.11.30.21266952v1)
-https://bimsbstatic.mdc-berlin.de/akalin/AAkalin_pathogenomics/sarscov2_ww_reports/211104_pub_version/index.html 
+https://bimsbstatic.mdc-berlin.de/akalin/AAkalin_pathogenomics/sars-cov-2_reports/211104_pub_version/index.html
 
 # Getting help
 
 If you have any questions please e-mail: pigx@googlegroups.com or use the web form to ask questions https://groups.google.com/forum/#!forum/pigx/. 
 
-If you run into any bugs, please open an issue here: https://github.com/BIMSBbioinfo/pigx_sarscov2_ww/issues. 
+If you run into any bugs, please open an issue here: https://github.com/BIMSBbioinfo/pigx_sars-cov-2/issues.
 
 # Links
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl -*- Autoconf -*-
 
-AC_INIT([PiGx_sars-cov2-ww], [m4_translit(m4_esyscmd([cat VERSION]),m4_newline)])
+AC_INIT([PiGx_sars-cov-2], [m4_translit(m4_esyscmd([cat VERSION]),m4_newline)])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([gnu color-tests tar-pax -Wall -Wno-portability foreign])
@@ -94,5 +94,5 @@ AC_CONFIG_FILES([tests/tests/vep.sh], [chmod +x tests/tests/vep.sh])
 AC_CONFIG_FILES([test.sh], [chmod +x test.sh])
 AC_CONFIG_FILES([scripts/download_databases.sh], [chmod +x scripts/download_databases.sh])
 AC_CONFIG_FILES([qsub-template.sh:pigx-common/common/qsub-template.sh.in])
-AC_CONFIG_FILES([pigx-sars-cov2-ww:pigx-common/common/pigx-runner.in], [chmod +x pigx-sars-cov2-ww])
+AC_CONFIG_FILES([pigx-sars-cov-2:pigx-common/common/pigx-runner.in], [chmod +x pigx-sars-cov-2])
 AC_OUTPUT

--- a/guix.scm
+++ b/guix.scm
@@ -1,7 +1,7 @@
-;;; PiGx SARS-CoV2 wastewater sequencing pipeline
+;;; PiGx SARS-CoV-2 wastewater sequencing pipeline
 ;;; Copyright © 2021 Ricardo Wurmus <rekado@elephly.net>
 ;;;
-;;; This file is part of PiGx SARS-CoV2 wastewater sequencing pipeline
+;;; This file is part of PiGx SARS-CoV-2 wastewater sequencing pipeline
 ;;;
 ;;; This is free software; see LICENSE file for details.
 
@@ -20,20 +20,20 @@
 (define %version
   (symbol->string (with-input-from-file "VERSION" read)))
 
-(define-public pigx-sars-cov2-ww-development
+(define-public pigx-sars-cov-2-development
   (package
-    (name "pigx-sars-cov2-ww")
+    (name "pigx-sars-cov-2")
     (version %version)
     (source
-     (string-append (getcwd) "/pigx_sars-cov2-ww-" version ".tar.gz"))
+     (string-append (getcwd) "/pigx_sars-cov-2-" version ".tar.gz"))
     (build-system gnu-build-system)
     (inputs
      (map p %packages))
     (native-inputs
      (map p %native-packages))
-    (home-page "http://bioinformatics.mdc-berlin.de/pigx/")
-    (synopsis "SARS-CoV2 wastewater sequencing pipeline")
+    (home-page "https://bioinformatics.mdc-berlin.de/pigx/")
+    (synopsis "SARS-CoV-2 wastewater sequencing pipeline")
     (description "")
     (license gpl3+)))
 
-pigx-sars-cov2-ww-development
+pigx-sars-cov-2-development

--- a/manifest.scm
+++ b/manifest.scm
@@ -1,7 +1,7 @@
-;;; PiGx SARS-CoV2 wastewater sequencing pipeline
+;;; PiGx SARS-CoV-2 wastewater sequencing pipeline
 ;;; Copyright © 2021 Ricardo Wurmus <rekado@elephly.net>
 ;;;
-;;; This file is part of PiGx SARS-CoV2 wastewater sequencing pipeline
+;;; This file is part of PiGx SARS-CoV-2 wastewater sequencing pipeline
 ;;;
 ;;; This is free software; see LICENSE file for details.
 ;;;

--- a/scripts/report_scripts/index.Rmd
+++ b/scripts/report_scripts/index.Rmd
@@ -69,12 +69,12 @@ lineages and single nucleotide (single-NT) mutations.
 
 The visualizations below provide an overview of the evolution of VOCs found
 in the analyzed samples across given time points and locations. The abundance values for the variants are derived 
-by deconvolution. For details please consult the [documentation](http://bioinformatics.mdc-berlin.de/pigx_docs/pigx-sars-cov2-ww.html#output-description))
+by deconvolution. For details please consult the [documentation](http://bioinformatics.mdc-berlin.de/pigx_docs/pigx-sars-cov-2.html#output-description))
 
 This pipeline is part of
 [PiGx](https://bioinformatics.mdc-berlin.de/pigx), a collection of
 highly reproducible genomics pipelines
-[developed](https://github.com/BIMSBbioinfo/pigx_sarscov2_ww) by the
+[developed](https://github.com/BIMSBbioinfo/pigx_sars-cov-2) by the
 [Bioinformatics & Omics Data Science
 platform](https://bioinformatics.mdc-berlin.de/) at the Berlin
 Institute of Medical System Biology (BIMSB).

--- a/scripts/report_scripts/qc_report_per_sample.Rmd
+++ b/scripts/report_scripts/qc_report_per_sample.Rmd
@@ -32,7 +32,7 @@ library(base64url)
 ```
 
 This report provides an overview over general quality control measures of the sample  and provides the summarized data as downloadable tables. 
-For detailed information about the methods please consult the [documentation](http://bioinformatics.mdc-berlin.de/pigx_docs/pigx-sars-cov2-ww.html#output-description). 
+For detailed information about the methods please consult the [documentation](http://bioinformatics.mdc-berlin.de/pigx_docs/pigx-sars-cov-2.html#output-description).
 
 ```{r reading data, include = FALSE}
 coverage.df <- read.table(params$coverage_file, sep = "\t", header = T)
@@ -76,7 +76,7 @@ datatable(t(Coverage), options = list(searching = FALSE, paging = FALSE))
 # Read processing
 
 To improve alignment rates and mutation calling the pipeline contains trimming steps for primer, read-quality and adapter trimming. Parameter for read processing can be provided by [the pipeline’s settings file](link/to/etc/settings_file). For detailed method information please
-consult the [documentation](http://bioinformatics.mdc-berlin.de/pigx_docs/pigx-sars-cov2-ww.html#introduction).   
+consult the [documentation](http://bioinformatics.mdc-berlin.de/pigx_docs/pigx-sars-cov-2.html#introduction).
 
 ## MultiQC 
 In order to be able to assess and compare the read quality after each step multiple quality reports are generated which are presented below in a summarized format:

--- a/scripts/report_scripts/variantreport_p_sample.Rmd
+++ b/scripts/report_scripts/variantreport_p_sample.Rmd
@@ -56,7 +56,7 @@ coordinates_long <- as.character(sample_sheet[name==sample_name]$coordinates_lon
 
 ``` 
 
-This lineage analysis report provides an overview over all mutations found in the sample and the deconvoluted lineage abundances. The tables below display the summarized results from single-nucleotide-variant (SNV) calling and their translation into protein mutations. A bar chart visualizes the proportions of lineages that are derived by deconvolution of the set of mutations that is matching the provided list of lineage - characterizing mutations (signature mutations). For detailed method description please consult the [documentation](http://bioinformatics.mdc-berlin.de/pigx_docs/pigx-sars-cov2-ww.html#output-description)  
+This lineage analysis report provides an overview over all mutations found in the sample and the deconvoluted lineage abundances. The tables below display the summarized results from single-nucleotide-variant (SNV) calling and their translation into protein mutations. A bar chart visualizes the proportions of lineages that are derived by deconvolution of the set of mutations that is matching the provided list of lineage - characterizing mutations (signature mutations). For detailed method description please consult the [documentation](http://bioinformatics.mdc-berlin.de/pigx_docs/pigx-sars-cov-2.html#output-description)
 *Note: Deconvolution results are biased by the number of reads and by the number of signature mutations that were found for this sample.  Check with the QC report to be able to assess how trustworthy the results are.*
 
 ```{r function_parse_snv_csv, include = FALSE, warning = F, message = F}
@@ -305,7 +305,7 @@ DT::datatable(NoSignatureTable,
 ```
 
 # Lineage analysis
-Lineage proportion values are derived by deconvolution of the tracked signature mutations. Deconvolution is done by using a robust regression model. It aims to predict the individual contributions of the lineages to the observed mutation frequencies in the bulk wastewater sample. For detailed method description, please consult the [documentation](https://bioinformatics.mdc-berlin.de/pigx_docs/pigx-sars-cov2-ww.html#output-description)
+Lineage proportion values are derived by deconvolution of the tracked signature mutations. Deconvolution is done by using a robust regression model. It aims to predict the individual contributions of the lineages to the observed mutation frequencies in the bulk wastewater sample. For detailed method description, please consult the [documentation](https://bioinformatics.mdc-berlin.de/pigx_docs/pigx-sars-cov-2.html#output-description)
 
 
 ```{r getting_unique_muts_bulk, message=F, warning=F, include = FALSE}

--- a/snakefile.py
+++ b/snakefile.py
@@ -1,8 +1,8 @@
-# PiGx SARS CoV2 wastewater sequencing pipeline
+# PiGx SARS-CoV-2 wastewater sequencing pipeline
 #
 # Copyright © 2021 Akalin lab.
 #
-# This file is part of the PiGx SARS-CoV2 wastewater sequencing pipeline.
+# This file is part of the PiGx SARS-CoV-2 wastewater sequencing pipeline.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Snakefile for PiGx SARS CoV2 wastewater sequencing pipeline
+Snakefile for PiGx SARS-CoV-2 wastewater sequencing pipeline
 """
 
 import os
@@ -594,7 +594,7 @@ rule render_index:
       qc=expand(os.path.join(REPORT_DIR, "{sample}.qc_report_per_sample.html"), sample = SAMPLES),
       variant=expand(os.path.join(REPORT_DIR, "{sample}.variantreport_p_sample.html"), sample = SAMPLES)
     # TODO: these CSV files should be declared as inputs!  Due to
-    # https://github.com/BIMSBbioinfo/pigx_sarscov2_ww/issues/19 we
+    # https://github.com/BIMSBbioinfo/pigx_sars-cov-2/issues/19 we
     # cannot do this yet, so we just add the variant reports for all
     # samples as inputs.
     params:

--- a/snakefile.py
+++ b/snakefile.py
@@ -5,7 +5,6 @@
 # This file is part of the PiGx SARS-CoV2 wastewater sequencing pipeline.
 #
 # This program is free software: you can redistribute it and/or modify
-# This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.

--- a/test.sh.in
+++ b/test.sh.in
@@ -14,7 +14,7 @@ chmod -R +w ${srcdir}/tests
 
 # Perform a full paired end run
 
-${builddir}/pigx-sars-cov2-ww --printshellcmds -s ${srcdir}/tests/settings.yaml ${srcdir}/tests/sample_sheet.csv
+${builddir}/pigx-sars-cov-2 --printshellcmds -s ${srcdir}/tests/settings.yaml ${srcdir}/tests/sample_sheet.csv
 
 if ! test -f "${srcdir}/tests/output/report/index.html"
 then


### PR DESCRIPTION
This pull request renames the tool and repository URLs to "pigx-sars-cov-2", dropping the "ww" and unifying the spelling throughout.

Once that's merged this repository should be renamed, and the documentation at pigx_docs should be changed.