### PR TITLE
Set mutation covered percentage threshold in tests to 25

### DIFF
--- a/tests/settings.yaml
+++ b/tests/settings.yaml
@@ -10,4 +10,8 @@ locations:
   vep-db-dir: /local/Projects/AAkalin_pathogenomics/pigx_sars-cov-2_project/databases/vep_db
 
 reporting:
+  # This leads to enough samples being used that the mutation regression
+  # will run, meaning now most analysis code actually runs during
+  # testing. The results may be unrealistic, but we don't care about that
+  # during testing.
   mutation-coverage-threshold: 25

--- a/tests/settings.yaml
+++ b/tests/settings.yaml
@@ -8,3 +8,6 @@ locations:
   kraken-db-dir: /local/Projects/AAkalin_pathogenomics/pigx_sars-cov-2_project/databases/kraken_db
   krona-db-dir: /local/Projects/AAkalin_pathogenomics/pigx_sars-cov-2_project/databases/krona_db
   vep-db-dir: /local/Projects/AAkalin_pathogenomics/pigx_sars-cov-2_project/databases/vep_db
+
+reporting:
+  mutation-coverage-threshold: 25


### PR DESCRIPTION
  This leads to enough samples being used that the mutation regression
  will run, meaning now most analysis code actually runs now during
  testing. The results may be unrealistic, but we don't care about that
  during testing.