### PR TITLE
point automake flag to pigx-common m4 dir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-ACLOCAL_AMFLAGS = -I m4
+ACLOCAL_AMFLAGS = -I pigx-common/common/m4
 
 nodist_bin_SCRIPTS = \
   pigx-sars-cov-2


### PR DESCRIPTION
Otherwise alocal complains about not finding the m4 dir with a warning. There didn't seem to be any other consequences.