### PR TITLE
Fix error in dedupe mat fun when all cols are same

### DIFF
--- a/scripts/deconvolution_funs.R
+++ b/scripts/deconvolution_funs.R
@@ -229,7 +229,7 @@ dedupe_sigmut_mat <- function(sigmut_mat, var_sep = "_") {
 
   # generate deduped signature matrix
   # is a col was duplicated this contains only the first col of each dupe group
-  msig_deduped_df <- sigmut_mat_df[, !is_dupe] %>%
+  msig_deduped_df <- sigmut_mat_df[, !is_dupe, drop = FALSE] %>%
     rename(!!dupe_group_names) %>%
     replace(is.na(.), 0)
 


### PR DESCRIPTION
  In that case the deduped matrix would only have a single col after
  subsetting, which by default will be turned to a vector by the `[`
  operator. This behavior is now disabled.