### PR TITLE
Enable guix pull for the install action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install GNU Guix
         uses: PromyLOPh/guix-install-action@v1.4
         with:
-          pullAfterInstall: false
+          pullAfterInstall: true
       - name: Describe Guix
         run: echo "guix-commit=$(guix describe | grep commit | join -a1 -o1.2 - /dev/null)" >> $GITHUB_OUTPUT
         id: guix-commit


### PR DESCRIPTION
  Necessary, as the CI server for Guix currently does not provide up to
  date binaries.

Closes #164

(Already completed successfully on [jonasfreimuth/fix-action](https://github.com/jonasfreimuth/pigx_sars-cov-2/tree/fix-action), a WIP branch I created before I opened the issue and this linked branch)